### PR TITLE
feat: support usage in AWS AppSync environment

### DIFF
--- a/src/astToBody.js
+++ b/src/astToBody.js
@@ -42,6 +42,7 @@ function extractSelectionSet(set, variables, fragments) {
   set.selections.forEach((el) => {
     if (el.kind === 'FragmentSpread') {
       const fragment = fragments[el.name.value];
+      if(!fragment) { return }
       const selectionSet = extractSelectionSet(
         fragment.selectionSet,
         variables,

--- a/src/astToBody.js
+++ b/src/astToBody.js
@@ -41,8 +41,10 @@ function extractSelectionSet(set, variables, fragments) {
 
   set.selections.forEach((el) => {
     if (el.kind === 'FragmentSpread') {
+      if (fragments === null) {
+        return;
+      }
       const fragment = fragments[el.name.value];
-      if(!fragment) { return }
       const selectionSet = extractSelectionSet(
         fragment.selectionSet,
         variables,

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import { astToBody } from './astToBody';
 import { Symbols } from './constants';
 import { get, clean } from './utils';
+export { getAst } from './test-utils';
 
 export function parse(ast) {
   const body = astToBody(ast);

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,5 +1,5 @@
-import { parse, getFields, getArgs } from './index';
-import { ast } from './test-utils';
+import { parse, getFields, getArgs, getAst } from './index';
+import { ast, example } from './test-utils';
 
 test('getArgs can retrieve the root arguments', () => {
   const args = getArgs(ast, '');
@@ -143,5 +143,18 @@ test('getFields creator instance correctly handles nested objects with depth', (
     author: true,
     likes: { actor: true },
     message: true,
+  });
+});
+
+describe('AppSync environment', () => {
+  test('It should create an ast without fragments', () => {
+    expect(getAst(example, true).fragments).toBe(null);
+  });
+  test('It should should ignore fragments', () => {
+    const { getFields } = parse(getAst(example, true));
+    const fields = getFields('comments.likes', { depth: -1 });
+    expect(fields).toEqual({
+      actor: {},
+    });
   });
 });

--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -1,6 +1,6 @@
 import { parse } from 'graphql';
 
-export function getAst({ query, variables }) {
+export function getAst({ query, variables }, isAppSyncSelectionSet = false) {
   const ast = parse(query);
 
   const operation = ast.definitions.find(
@@ -17,30 +17,30 @@ export function getAst({ query, variables }) {
   return {
     fieldNodes: operation.selectionSet.selections,
     variableValues: variables,
-    fragments,
+    fragments: !isAppSyncSelectionSet ? fragments : null,
   };
 }
 
-export const ast = getAst({
-  query: `
-    query ($where: CommentFilterInput!) {
-      blog (id: "blog_1") {
+export const example = {
+  query: /* GraphQL */ `
+    query($where: CommentFilterInput!) {
+      blog(id: "blog_1") {
         id
         title
-        
+
         author(id: "author_1") {
           name
         }
-        
+
         comment(where: { id: "comment_1" }) {
           id
         }
-        
+
         comments(where: $where) {
           id
           message
           author
-          
+
           likes(where: { type: "heart" }) {
             actor {
               ...Person
@@ -49,7 +49,7 @@ export const ast = getAst({
         }
       }
     }
-    
+
     fragment Person on Actor {
       name
       email
@@ -60,4 +60,6 @@ export const ast = getAst({
       id: 'comment_2',
     },
   },
-});
+};
+
+export const ast = getAst(example);


### PR DESCRIPTION
Since the context in AWS AppSync resolvers has no information about fragments (see https://github.com/aws/aws-appsync-community/issues/142) this PR ignores an AST without fragments. This is accomplished by letting extractSelectionSet return early instead of throwing.

For convenience the getAst method is exported. This makes it easy to create of an AST using the resolvers [context info](https://docs.aws.amazon.com/appsync/latest/devguide/resolver-context-reference.html#aws-appsync-resolver-context-reference-info ) data.