### PR TITLE
feat: support GraphQL all type args

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -59,6 +59,21 @@ test('getArgs returns a creator instance when called with single argument', () =
   });
 });
 
+test('getArgs can retrieve the mixed arguments', () => {
+  const args = getArgs(ast, 'mixed');
+
+  expect(args).toEqual({
+    where: {
+      e: 'App',
+      w: { id: 'comment_2' },
+      id: 'mixed_id',
+      args: [1, true, 'true', null, { a: 'b' }],
+      x: { a: { b: 'c' } },
+      array: [1, 2, 3, 4, 3.14],
+    },
+  });
+});
+
 test('getFields can return the root level', () => {
   const fields = getFields(ast, '');
 

--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -47,6 +47,19 @@ export const example = {
             }
           }
         }
+        mixed(
+          where: {
+            e: App
+            w: $where
+            id: "mixed_id"
+            args: [1, true, "true", null, { a: "b" }]
+            x: { a: { b: "c" } }
+            array: [1, 2, 3, 4, 3.14]
+          }
+        ) {
+          id
+          name
+        }
       }
     }
 


### PR DESCRIPTION
One day, while I was doing AST parsing, I came across this repository and found that the support for all GQL types was incomplete. I made improvements on my end to support parameter parsing for all GQL types.

- [x] Added test cases passed.
- [x] Added code coverage cases, all covered and passed.




有一天我在做AST解析时找到了这个仓库，发现对所有的GQL的类型支持不完善，我这边进行了完善。 可以支持所有GQL类型的参数解析   
- [x] 新增测试用例通过
- [x] 新增代码覆盖用例全部覆盖且通过
